### PR TITLE
Bump version (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## [v0.1.0](https://github.com/NubeIO/nubeio-rubix-app-rubix-broker-go/tree/v0.1.0) (2022-08-09)
+
+- Make that app compatible with rubix-service v1.20.0 (breaking change)
+
 ## [v0.0.2](https://github.com/NubeIO/nubeio-rubix-app-rubix-broker-go/tree/v0.0.2) (2022-04-21)
 
 - Update configor: enable_persistence default true can override


### PR DESCRIPTION
### Summary

- Make that app compatible with rubix-service v1.20.0 (breaking change)